### PR TITLE
WIP Trying to fix installation of Python bindings.

### DIFF
--- a/dawn/CMakeLists.txt
+++ b/dawn/CMakeLists.txt
@@ -126,10 +126,11 @@ function(target_add_dawn_standard_props target)
 endfunction()
 
 # Protobuf
+#if(NOT DAWN_BUILD_PROTOBUF)
+#  find_package(Protobuf 3.4.0)
+#endif()
+#if(NOT Protobuf_FOUND)
 if(NOT DAWN_BUILD_PROTOBUF)
-  find_package(Protobuf 3.4.0)
-endif()
-if(NOT Protobuf_FOUND)
   include(FetchProtobuf)
 endif()
 

--- a/dawn/src/dawn4py/CMakeLists.txt
+++ b/dawn/src/dawn4py/CMakeLists.txt
@@ -69,6 +69,6 @@ pybind11_add_module(_dawn4py MODULE _dawn4py.cpp)
 target_compile_features(_dawn4py PUBLIC cxx_std_17)
 target_link_libraries(_dawn4py PUBLIC pybind11::pybind11 Dawn)
 target_compile_options(_dawn4py PUBLIC -Wno-shadow)
-set_target_properties(_dawn4py PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/dawn4py)
+#set_target_properties(_dawn4py PROPERTIES
+#  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/dawn4py)
 add_dependencies(_dawn4py generate_python_proto)

--- a/dawn/src/dawn4py/_version.py.in
+++ b/dawn/src/dawn4py/_version.py.in
@@ -13,5 +13,5 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-__versioninfo__ = (0, 0, 1)  # TODO: set automatically
+__versioninfo__ = {VERSION}   # Automatically set in 'setup.py'
 __version__ = ".".join(str(v) for v in __versioninfo__)


### PR DESCRIPTION
With the current changes, the compilation process when doing a `pip install` always succeeds (both in regular and editable mode) but there are still two problems:

- In editable mode seems that the final copy of the built .so to the destination folder fails

```
    "copying build/temp.linux-x86_64-3.6/src/dawn4py/_dawn4py.cpython-36m-x86_64-linux-gnu.so -> build/lib.linux-x86_64-3.6/dawn4py
    error: could not create 'build/lib.linux-x86_64-3.6/dawn4py/_dawn4py.cpython-36m-x86_64-linux-gnu.so': No such file or directory"
```


- In regular mode, the package is fully built and installed, but the protocol buffer python files are missing and thus `dawn4py` import fails

I think the Python side of the installation is more or less fixed, and the remaining issues should be fixed in the CMake side.

### Testing

I would consider this branch fully fixed as soon as the following script suceeds:
```

#!/bin/bash

set -e
set -x

git clone -b dockerize git@github.com:jdahm/dawn.git dawn_dockerize_test
cd dawn_dockerize_test

# Regular install in a new environment
rm -rf .venv_clean && python3 -m venv .venv_clean
source .venv_clean/bin/activate
which python
pip install --upgrade pip setuptools wheel
pip install ./dawn --verbose
python -c 'import dawn4py; print(dawn4py.__version__)'
deactivate

# Editable install in a new environment
rm -rf .venv_dev && python3 -m venv .venv_dev
source .venv_dev/bin/activate
which python
pip install --upgrade pip setuptools wheel
pip install -e ./dawn --verbose
python -c 'import dawn4py; print(dawn4py.__version__)'
deactivate

# Regular install in a new environment AFTER building dawn4py in-place
rm -rf .venv_dirty && python3 -m venv .venv_dirty
source .venv_dirty/bin/activate
which python
pip install --upgrade pip setuptools wheel
pip install ./dawn --verbose
python -c 'import dawn4py; print(dawn4py.__version__)'
deactivate


```